### PR TITLE
fix tests and an accessibility bug by using "%+A" instead of "%A"

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6431,7 +6431,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                         yield { ilMethodDef with Access=reprAccess }
                  | _ -> 
                      ()
-              | TUnionRepr _ when (not <| tycon.HasOverride cenv.g "ToString" []) -> 
+              | TUnionRepr _ when (not <| tycon.HasMember cenv.g "ToString" []) -> 
                   match (eenv.valsInScope.TryFind cenv.g.sprintf_vref.Deref,
                          eenv.valsInScope.TryFind cenv.g.new_format_vref.Deref) with
                   | Some(Lazy(Method(_,_,sprintfMethSpec,_,_,_))), Some(Lazy(Method(_,_,newFormatMethSpec,_,_,_))) ->

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6456,7 +6456,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                                                          (true,[],2,
                                                           nonBranchingInstrsToCode 
                                                             ([ // load the hardwired format string
-                                                               yield I_ldstr "%A"  
+                                                               yield I_ldstr "%+A"  
                                                                // make the printf format object
                                                                yield mkNormalNewobj newFormatMethSpec
                                                                // call sprintf
@@ -6467,7 +6467,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                                                                   yield mkNormalLdobj ilThisTy  ] @
                                                              callInstrs),
                                                           None))
-                      yield ilMethodDef
+                      let mdef = { ilMethodDef with CustomAttrs = mkILCustomAttrs [ cenv.g.CompilerGeneratedAttribute ] }
+                      yield mdef
                   | None,_ -> ()
                   | _,None -> ()
                   | _ -> ()

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -7614,10 +7614,22 @@ type Entity with
                                          argInfos.Length = 1 && 
                                          List.lengthsEqAndForall2 (typeEquiv g) (List.map fst (List.head argInfos)) argtys  &&  
                                          membInfo.MemberFlags.IsOverrideOrExplicitImpl) 
+    
+    member tycon.HasMember g nm argtys = 
+        tycon.TypeContents.tcaug_adhoc 
+        |> NameMultiMap.find nm
+        |> List.exists (fun vref -> 
+                          match vref.MemberInfo with 
+                          | None -> false 
+                          | _ -> let argInfos = ArgInfosOfMember g vref 
+                                 argInfos.Length = 1 && 
+                                 List.lengthsEqAndForall2 (typeEquiv g) (List.map fst (List.head argInfos)) argtys) 
+
 
 type EntityRef with 
     member tcref.HasInterface g ty = tcref.Deref.HasInterface g ty
     member tcref.HasOverride g nm argtys = tcref.Deref.HasOverride g nm argtys
+    member tcref.HasMember g nm argtys = tcref.Deref.HasMember g nm argtys
 
 let mkFastForLoop g (spLet,m,idv:Val,start,dir,finish,body) =
     let dir = if dir then FSharpForLoopUp else FSharpForLoopDown 

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -1396,10 +1396,12 @@ val IsGenericValWithGenericContraints: TcGlobals -> Val -> bool
 type Entity with 
     member HasInterface : TcGlobals -> TType -> bool
     member HasOverride : TcGlobals -> string -> TType list -> bool
+    member HasMember : TcGlobals -> string -> TType list -> bool
 
 type EntityRef with 
     member HasInterface : TcGlobals -> TType -> bool
     member HasOverride : TcGlobals -> string -> TType list -> bool
+    member HasMember : TcGlobals -> string -> TType list -> bool
 
 val (|AttribBitwiseOrExpr|_|) : TcGlobals -> Expr -> (Expr * Expr) option
 val (|EnumExpr|_|) : TcGlobals -> Expr -> Expr option

--- a/tests/fsharp/core/libtest/test.fsx
+++ b/tests/fsharp/core/libtest/test.fsx
@@ -5217,8 +5217,8 @@ module Repro_3947 = begin
   do  check "Bug3947.Internal%+A" (sprintf "%+A (%+A)" ITA (ITB 2)) "ITA (ITB 2)"
 
   // The follow are not very useful outputs, but adding regression tests to pick up any changes...
-  do  check "Bug3947.Internal%A.ITA" true (let str = sprintf "%A" ITA     in str.EndsWith("InternalType+_ITA"))
-  do  check "Bug3947.Internal%A.ITB" true (let str = sprintf "%A" (ITB 2) in str.EndsWith("InternalType+ITB"))
+  do  check "Bug3947.Internal%A.ITA" (sprintf "%A" ITA) "ITA"
+  do  check "Bug3947.Internal%A.ITB" (sprintf "%A" (ITB 2)) "ITB 2"
 end
 
 

--- a/tests/fsharp/core/members/basics/test.fs
+++ b/tests/fsharp/core/members/basics/test.fs
@@ -1114,15 +1114,15 @@ module ToStringOnUnionTest = begin
 
 end
 
-module ToStringOnUnionTest = begin
+module ToStringOnUnionTestOverride = begin
 
   type MyUnion = A of string | B
     with
       override x.ToString() = "MyUnion"
 
   let a1 = A "FOO"
-  do test "union-tostring-with-override" (a1.ToString() = "MyUnion))")
-  do test "union-sprintfO-with-override" ((sprintf "%O" a1) = "MyUnion))")
+  do test "union-tostring-with-override" (a1.ToString() = "MyUnion")
+  do test "union-sprintfO-with-override" ((sprintf "%O" a1) = "MyUnion")
 
 end
 


### PR DESCRIPTION
Hey, 

With these changes, the PR now runs with only some IL fsharpqa test errors. The main issue causing the StackOverflow Exception was that the format string `"%A"` means only publicly accessible unions can printed and one of the test cases had an internal union, which "%A" would not allow access to. Using the `"%+A"` format string fixes that issue.

There were also some random typos in the test cases and a few that needed to be updated as well.

I'm not sure what the fastest way to update the IL comparisons is.