### PR TITLE
fix MissingCommaInCtor test

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -2054,7 +2054,7 @@ and ReportNoCandidatesError (csenv:ConstraintSolverEnv) (nUnnamedCallerArgs,nNam
                         cmeth.ArgSets
                         |> List.exists (fun argSet ->
                             argSet.UnnamedCallerArgs 
-                            |> List.exists (fun c -> c.Expr.ToString().EndsWith "Sequential"))
+                            |> List.exists (fun c -> c.Expr.ToString().StartsWith "Sequential"))
 
                     if couldBeNameArgs then
                         Error (FSComp.SR.csCtorSignatureMismatchArityProp(methodName, nReqd, nActual, signature), m)


### PR DESCRIPTION
@colinbull @forki Okay this should fix the last failing test for RFC FS-1022. That test (MissingCommaInCtor ) used a union's `ToString` to determine the correct error message so changing the `ToString` meant that the test had to modified as well from `EndsWith` to `StartsWith`.