### PR TITLE
various fixes

### DIFF
--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -195,6 +195,7 @@ type ILScopeRef =
     member ModuleRef: ILModuleRef
     member AssemblyRef: ILAssemblyRef
     member QualifiedName: string
+    member QualifiedNameWithNoShortPrimaryAssembly: string
 
 // Calling conventions.  
 //

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3733,6 +3733,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
     let mutable ilGlobalsOpt = ilGlobalsOpt
     let mutable tcGlobals = None
 #if EXTENSIONTYPING
+    let mutable ccuBeingCompiledHack : CcuThunk option = None
     let mutable generatedTypeRoots = new System.Collections.Generic.Dictionary<ILTypeRef, int * ProviderGeneratedType>()
 #endif
     
@@ -3842,38 +3843,69 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
         CheckDisposed()
         match tcImports.FindCcuInfo(ctok, m, assemblyName, lookupOnly) with
         | ResolvedImportedAssembly(importedAssembly) -> ResolvedCcu(importedAssembly.FSharpViewOfMetadata)
-        | UnresolvedImportedAssembly(assemblyName) -> UnresolvedCcu(assemblyName)
+        | UnresolvedImportedAssembly(assemblyName) -> 
+#if EXTENSIONTYPING
+            match ccuBeingCompiledHack with 
+            | Some thisCcu when thisCcu.AssemblyName = assemblyName -> ResolvedCcu(thisCcu)
+            | _ -> 
+#endif
+                UnresolvedCcu(assemblyName)
 
-    member tcImports.FindCcuFromAssemblyRef(ctok, m, assref:ILAssemblyRef) = 
-        CheckDisposed()
-        match tcImports.FindCcuInfo(ctok, m, assref.Name, lookupOnly=false) with
-        | ResolvedImportedAssembly(importedAssembly) -> ResolvedCcu(importedAssembly.FSharpViewOfMetadata)
-        | UnresolvedImportedAssembly _ -> UnresolvedCcu(assref.QualifiedName)
+    member tcImports.FindCcuFromScopeRef(ctok, m, scoref) = 
+        match scoref with 
+        | ILScopeRef.Local    -> 
+#if EXTENSIONTYPING
+                match ccuBeingCompiledHack with 
+                | Some thisCcu -> ResolvedCcu(thisCcu)
+                | _ -> 
+#endif
+                    UnresolvedCcu("local")
+        | ILScopeRef.Module _ -> error(InternalError("FindCcuFromScopeRef: reference found to a type in an auxiliary module",m))
+        | ILScopeRef.Assembly assref -> 
+
+            CheckDisposed()
+            match tcImports.FindCcuInfo(ctok, m, assref.Name, lookupOnly=false) with
+            | ResolvedImportedAssembly(importedAssembly) -> ResolvedCcu(importedAssembly.FSharpViewOfMetadata)
+            | UnresolvedImportedAssembly _ -> 
+#if EXTENSIONTYPING
+                match ccuBeingCompiledHack with 
+                | Some thisCcu when thisCcu.AssemblyName = assref.Name -> ResolvedCcu(thisCcu)
+                | _ -> 
+#endif
+                    UnresolvedCcu(assref.QualifiedName)
 
 
 #if EXTENSIONTYPING
     member tcImports.ImportQualifiedTypeNameAsTypeValue(qname:string, m) = 
-        if not (qname.Contains(",")) then failwith (sprintf "expected a qualified type name: %+A" qname)
+        // Qualified name string --> TyconRef 
+        assert (qname.Contains(",")) // we expected a qualified type name, even for references to the assembly being compiled
         let commaPos = qname.IndexOf ','
-        let typeName = qname.[0..commaPos-1] 
-        let assName = if commaPos+2 < qname.Length then qname.[commaPos+2..]  else ""
-        let ilAssRef = ILAssemblyRef.FromAssemblyName (System.Reflection.AssemblyName assName)
-        // TODO: nested type definitions
-        if typeName.Contains("+") then failwith (sprintf "nested type def: %+A" typeName)
-        let ilTypeRef = ILTypeRef.Create(ILScopeRef.Assembly ilAssRef, [], typeName)
+        let ilTypeRef = 
+            if commaPos >= 0 then 
+                let typeName = qname.[0..commaPos-1] 
+                let assName = if commaPos+2 < qname.Length then qname.[commaPos+2..]  else ""
+                let ilAssRef = ILAssemblyRef.FromAssemblyName (System.Reflection.AssemblyName assName)
+                let ilScoRef = ILScopeRef.Assembly ilAssRef
+                if typeName.Contains("+") then 
+                    let pieces = typeName.Split('+')
+                    ILTypeRef.Create(ilScoRef, Array.toList pieces.[0..pieces.Length-2], pieces.[pieces.Length-1])
+                else
+                    ILTypeRef.Create(ilScoRef, [], typeName)
+            else 
+                ILTypeRef.Create(ILScopeRef.Local, [], qname)
+                
         let tcref = Import.ImportILTypeRef (tcImports.GetImportMap()) m ilTypeRef 
-        tcImports.LinkTyconRefAsTypeValue(None, tcref, m)
-
-    member tcImports.LinkTyconRefAsTypeValue(thisCcuOpt, tcref: TyconRef, m) = 
+        // TyconRef --> ReflectTypeDefinition value
         let ccu = 
             match ccuOfTyconRef tcref with 
             | Some ccu -> ccu 
             | None -> 
-            match thisCcuOpt with 
+            match ccuBeingCompiledHack with 
             | Some ccu -> ccu 
             | None -> failwith (sprintf "TODO: didn't get back to CCU being compiled for local tcref %s" tcref.DisplayName)
-        let assm = TastReflect.ReflectAssembly(tcImports.GetTcGlobals(), ccu, "", m)
-        let rtd = assm.TxTypeDef None tcref
+        let asm = ccu.ReflectAssembly :?> TastReflect.ReflectAssembly
+        let rtd = asm.TxTypeDef None tcref
+        printfn "resurrected type value rtd.AssemblyQualifiedName='%s'" rtd.AssemblyQualifiedName
         rtd
 
     member tcImports.GetProvidedAssemblyInfo(ctok, m, assembly: Tainted<ProvidedAssembly>) = 
@@ -3926,10 +3958,12 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                 MemberSignatureEquality = (fun ty1 ty2 -> Tastops.typeEquivAux EraseAll g ty1 ty2)
                 ImportProvidedType = (fun ty -> Import.ImportProvidedType (tcImports.GetImportMap()) m ty)
                 ImportQualifiedTypeNameAsTypeValue = (fun (m,qname) ->  tcImports.ImportQualifiedTypeNameAsTypeValue (m, qname))
-                LinkTyconRefAsTypeValue = (fun (thisCcuOpt, tcref, m) ->  tcImports.LinkTyconRefAsTypeValue (thisCcuOpt, tcref, m))
+                ReflectAssembly = lazy null
+                GetCcuBeingCompiledHack = (fun () -> ccuBeingCompiledHack)
                 TypeForwarders = Map.empty }
                     
             let ccu = CcuThunk.Create(ilShortAssemName,ccuData)
+            ccuData.ReflectAssembly <- lazy (TastReflect.ReflectAssembly(g,ccu,fileName) :> _)
             let ccuinfo = 
                 { FSharpViewOfMetadata=ccu 
                   ILScopeRef = ilScopeRef 
@@ -3950,6 +3984,9 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
             | true,(index, _) -> index
             | false, _ -> generatedTypeRoots.Count
         generatedTypeRoots.[ilTyRef] <- (index, root)
+
+    member tcImports.SetCcuBeingCompiledHack thisCcu = 
+        ccuBeingCompiledHack <- Some thisCcu
 
     member tcImports.ProviderGeneratedTypeRoots = 
         generatedTypeRoots.Values
@@ -4026,8 +4063,8 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
         CheckDisposed()
         let loaderInterface = 
             { new Import.AssemblyLoader with 
-                 member x.FindCcuFromAssemblyRef (ctok, m, ilAssemblyRef) = 
-                     tcImports.FindCcuFromAssemblyRef (ctok, m,ilAssemblyRef)
+                 member x.FindCcuFromScopeRef (ctok, m, scoref) = 
+                     tcImports.FindCcuFromScopeRef (ctok, m,scoref)
 #if EXTENSIONTYPING
                  member x.GetProvidedAssemblyInfo (ctok, m, assembly) = tcImports.GetProvidedAssemblyInfo (ctok, m, assembly)
                  member x.RecordGeneratedTypeRoot root = tcImports.RecordGeneratedTypeRoot root
@@ -4251,6 +4288,8 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
         let auxModuleLoader = tcImports.MkLoaderForMultiModuleILAssemblies ctok m
         let invalidateCcu = new Event<_>()
         let ccu = Import.ImportILAssembly(tcImports.GetImportMap,m,auxModuleLoader,ilScopeRef,tcConfig.implicitIncludeDir, Some filename,ilModule,invalidateCcu.Publish)
+        ccu.Deref.ReflectAssembly <- lazy (TastReflect.ReflectAssembly(tcImports.GetTcGlobals(),ccu,filename) :> _)
+        ccu.Deref.GetCcuBeingCompiledHack <- (fun () -> Some ccu)
         
         let ilg = defaultArg ilGlobalsOpt EcmaMscorlibILGlobals
 
@@ -4312,13 +4351,15 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                       IsProviderGenerated = false
                       ImportProvidedType = (fun ty -> Import.ImportProvidedType (tcImports.GetImportMap()) m ty)
                       ImportQualifiedTypeNameAsTypeValue = (fun (m,qname) ->  tcImports.ImportQualifiedTypeNameAsTypeValue (m, qname))
-                      LinkTyconRefAsTypeValue = (fun (thisCcuOpt, tcref, m) ->  tcImports.LinkTyconRefAsTypeValue (thisCcuOpt, tcref, m))
+                      GetCcuBeingCompiledHack = (fun () -> ccuBeingCompiledHack)
+                      ReflectAssembly = lazy null
 #endif
                       UsesFSharp20PlusQuotations = minfo.usesQuotations
                       MemberSignatureEquality= (fun ty1 ty2 -> Tastops.typeEquivAux EraseAll (tcImports.GetTcGlobals()) ty1 ty2)
                       TypeForwarders = ImportILAssemblyTypeForwarders(tcImports.GetImportMap, m, ilModule.GetRawTypeForwarders()) }
 
                 let ccu = CcuThunk.Create(ccuName, ccuData)
+                ccuData.ReflectAssembly <- lazy (TastReflect.ReflectAssembly(tcImports.GetTcGlobals(),ccu,filename)  :> _)
 
                 let optdata = 
                     lazy 
@@ -5196,7 +5237,8 @@ let GetInitialTcState(m,ccuName,tcConfig:TcConfig,tcGlobals,tcImports:TcImports,
           IsProviderGenerated = false
           ImportProvidedType = (fun ty -> Import.ImportProvidedType (tcImports.GetImportMap()) m ty)
           ImportQualifiedTypeNameAsTypeValue = (fun (m,qname) ->  tcImports.ImportQualifiedTypeNameAsTypeValue (m, qname))
-          LinkTyconRefAsTypeValue = (fun (thisCcuOpt, tcref, m) ->  tcImports.LinkTyconRefAsTypeValue (thisCcuOpt, tcref, m))
+          GetCcuBeingCompiledHack = (fun () -> None)
+          ReflectAssembly = lazy null
 #endif
           FileName=None 
           Stamp = newStamp()
@@ -5208,6 +5250,11 @@ let GetInitialTcState(m,ccuName,tcConfig:TcConfig,tcGlobals,tcImports:TcImports,
           TypeForwarders=Map.empty }
 
     let ccu = CcuThunk.Create(ccuName,ccuData)
+
+    ccuData.ReflectAssembly <- lazy (TastReflect.ReflectAssembly(tcGlobals,ccu,ccuName + ".dll")  :> _)
+    ccuData.GetCcuBeingCompiledHack <- (fun () -> Some ccu)
+
+    tcImports.SetCcuBeingCompiledHack ccu
 
     // OK, is this is the FSharp.Core CCU then fix it up. 
     if tcConfig.compilingFslib then 
@@ -5235,6 +5282,7 @@ let TypeCheckOneInputEventually
       RequireCompilationThread ctok // Everything here requires the compilation thread since it works on the TAST
 
       CheckSimulateException(tcConfig)
+      tcImports.SetCcuBeingCompiledHack tcState.Ccu
       let (RootSigsAndImpls(rootSigs,rootImpls,allSigModulTyp,allImplementedSigModulTyp)) = tcState.tcsRootSigsAndImpls
       let m = inp.Range
       let amap = tcImports.GetImportMap()

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -610,7 +610,7 @@ type TcImports =
     member GetCcusExcludingBase : unit -> CcuThunk list 
     member FindDllInfo : CompilationThreadToken * range * string -> ImportedBinary
     member TryFindDllInfo : CompilationThreadToken * range * string * lookupOnly: bool -> option<ImportedBinary>
-    member FindCcuFromAssemblyRef : CompilationThreadToken * range * ILAssemblyRef -> CcuResolutionResult
+    member FindCcuFromScopeRef : CompilationThreadToken * range * ILScopeRef -> CcuResolutionResult
 #if EXTENSIONTYPING
     member ProviderGeneratedTypeRoots : ProviderGeneratedType list
 #endif

--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -1174,7 +1174,12 @@ module internal ExtensionTyping =
                           | "System.Boolean" -> box (arg = "True")
                           | "System.String" -> box (string arg)
                           | "System.Type" -> 
+                            // importQualifiedTypeNameAsTypeValue converts a string into a TastReflect.ReflectTypeDefinition which is handed to the
+                            // type provider as a 
                             let (ty : System.Type) = importQualifiedTypeNameAsTypeValue arg
+                            // The AssemblyQualifiedName on the System.Type instance should be precisely the same as the text of the mangled argument
+                            printfn "ty.AssemblyQualifiedName = '%s', arg = '%s'" ty.AssemblyQualifiedName arg
+                            assert (ty.AssemblyQualifiedName = arg)
                             box ty
                           | s -> error(Error(FSComp.SR.etUnknownStaticArgumentKind(s, typeLogicalName), range0)))
 

--- a/src/fsharp/ExtensionTyping.fsi
+++ b/src/fsharp/ExtensionTyping.fsi
@@ -328,10 +328,10 @@ module internal ExtensionTyping =
     /// Try to apply a provided type to the given static arguments. If successful also return a function 
     /// to check the type name is as expected (this function is called by the caller of TryApplyProvidedType
     /// after other checks are made).
-    val TryApplyProvidedType : typeBeforeArguments:Tainted<ProvidedType> * optGeneratedTypePath: string list option * staticArgs:obj[]  * range -> (Tainted<ProvidedType> * (unit -> unit)) option
+    val TryApplyProvidedType : typeBeforeArguments:Tainted<ProvidedType> * optGeneratedTypePath: string list option * staticArgs:PrettyNaming.StaticArg[]  * range -> (Tainted<ProvidedType> * (unit -> unit)) option
 
     /// Try to apply a provided method to the given static arguments. 
-    val TryApplyProvidedMethod : methBeforeArguments:Tainted<ProvidedMethodBase> * staticArgs:obj[]  * range -> Tainted<ProvidedMethodBase> option
+    val TryApplyProvidedMethod : methBeforeArguments:Tainted<ProvidedMethodBase> * staticArgs:PrettyNaming.StaticArg[]  * range -> Tainted<ProvidedMethodBase> option
 
     /// Try to resolve a type in the given extension type resolver
     val TryResolveProvidedType : Tainted<ITypeProvider> * range * string[] * typeName: string -> Tainted<ProvidedType> option

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -671,20 +671,30 @@ module internal Microsoft.FSharp.Compiler.PrettyNaming
             typeLogicalName + "," + nonDefaultArgsText
 
 
-    let computeMangledNameWithoutDefaultArgValues(nm,staticArgs:obj[],defaultArgValues) =
+    /// Compute the mangled value stored for a System.Type argument. Only the simple name of the assembly is stored.
+    let computeStringOfStaticTypeArg (st: System.Type) =
+        st.FullName + ", " + st.Assembly.GetName().Name 
+
+    type StaticArg = StaticArg of obj
+    
+    /// Compute the mangled value stored for a System.Type argument. Only the simple name of the assembly is stored.
+    let computeStringOfStaticArg (StaticArg staticArg) =
+        match staticArg with 
+        | :? System.Type as st -> 
+            let qname = computeStringOfStaticTypeArg st
+            printfn "name used in argument = '%s'" qname
+            qname
+        | _ -> 
+            //  Convert all other argument types to basic strings
+            string staticArg 
+        
+
+    let computeMangledNameWithoutDefaultArgValues(nm,staticArgs:StaticArg[],defaultArgValues) =
         let nonDefaultArgs = 
             (staticArgs,defaultArgValues) 
             ||> Array.zip 
             |> Array.choose (fun (staticArg, (defaultArgName, defaultArgValue)) -> 
-                let actualArgValue = 
-                    match staticArg with 
-                    | :? System.Type as st -> 
-                        let qname = st.AssemblyQualifiedName 
-                        printfn "st.AssemblyQualifiedName = '%s'" qname
-                        qname
-                    | _ -> 
-                        //  Convert all other argument types to basic strings
-                        string staticArg 
+                let actualArgValue = computeStringOfStaticArg staticArg
                 match defaultArgValue with 
                 | Some v when v = actualArgValue -> None
                 | _ -> Some (defaultArgName, actualArgValue))

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -678,8 +678,13 @@ module internal Microsoft.FSharp.Compiler.PrettyNaming
             |> Array.choose (fun (staticArg, (defaultArgName, defaultArgValue)) -> 
                 let actualArgValue = 
                     match staticArg with 
-                    | :? System.Type as st -> st.AssemblyQualifiedName
-                    | _ -> string staticArg 
+                    | :? System.Type as st -> 
+                        let qname = st.AssemblyQualifiedName 
+                        printfn "st.AssemblyQualifiedName = '%s'" qname
+                        qname
+                    | _ -> 
+                        //  Convert all other argument types to basic strings
+                        string staticArg 
                 match defaultArgValue with 
                 | Some v when v = actualArgValue -> None
                 | _ -> Some (defaultArgName, actualArgValue))

--- a/src/fsharp/QuotationTranslator.fs
+++ b/src/fsharp/QuotationTranslator.fs
@@ -910,7 +910,7 @@ and IsILTypeRefStaticLinkLocal cenv m (tr:ILTypeRef) =
                  // which import types (and resolve assemblies from the tcImports tables) happen on the compilation thread.
                  let ctok = AssumeCompilationThreadWithoutEvidence() 
 
-                 (match cenv.amap.assemblyLoader.FindCcuFromAssemblyRef (ctok, m,aref) with 
+                 (match cenv.amap.assemblyLoader.FindCcuFromScopeRef (ctok, m, ILScopeRef.Assembly aref) with 
                   | ResolvedCcu ccu -> ccu.IsProviderGenerated
                   | UnresolvedCcu _ -> false) 
             -> true

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4722,7 +4722,7 @@ and TcTyparConstraints cenv newOk checkCxs occ env tpenv wcs =
     let _,tpenv = List.fold (fun (ridx,tpenv) tc -> ridx - 1, TcTyparConstraint ridx cenv newOk checkCxs occ env tpenv tc) (List.length wcs - 1, tpenv) wcs
     tpenv
 
-#if EXTENSIONTYPING
+//#if EXTENSIONTYPING
 and TcStaticConstantParameter cenv (env:TcEnv) tpenv kind (v:SynType) idOpt container =
     let fail() = error(Error(FSComp.SR.etInvalidStaticArgument(NicePrint.minimalStringOfType env.DisplayEnv kind),v.Range)) 
     let record ttype =
@@ -4793,13 +4793,8 @@ and TcStaticConstantParameter cenv (env:TcEnv) tpenv kind (v:SynType) idOpt cont
                 | Exception err -> raise(err)
                 | Result tcref -> tcref 
 
-            let st = cenv.topCcu.LinkTyconRefAsTypeValue (Some cenv.topCcu, tcref, m)
-            //assm.GetType(tcref.CompiledRepresentationForNamedType.QualifiedName)
-            //TODO:: 
-                //Assemebly Reflection Starterpack. 
-                //Back type information with tycon ref.
-                //Types should be amortised, created only once. 
-                //Minimal implementation at first. 
+            let assm = cenv.topCcu.ReflectAssembly :?> TastReflect.ReflectAssembly
+            let st = assm.TxTType (snd (generalizeTyconRef tcref))
                 
             record(cenv.g.system_Type_typ); 
             box st, tpenv
@@ -4920,7 +4915,7 @@ and TcProvidedTypeApp cenv env tpenv tcref args m =
     else
         let typ = Import.ImportProvidedType cenv.amap m providedTypeAfterStaticArguments
         typ,tpenv 
-#endif
+//#endif
 
 /// Typecheck an application of a generic type to type arguments.
 ///

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4751,7 +4751,7 @@ and TcStaticConstantParameter cenv (env:TcEnv) tpenv kind (v:SynType) idOpt cont
             | SynConst.String (s,_) when s <> null && typeEquiv cenv.g cenv.g.string_ty kind  -> record(cenv.g.string_ty); box (s:string)
             | SynConst.Bool b       when typeEquiv cenv.g cenv.g.bool_ty kind    -> record(cenv.g.bool_ty); box (b:bool)
             | _ -> fail()
-        v, tpenv
+        PrettyNaming.StaticArg v, tpenv
     | SynType.StaticConstantExpr(e, _ ) ->
 
         // If an error occurs, don't try to recover, since the constant expression will be nothing like what we need
@@ -4781,7 +4781,7 @@ and TcStaticConstantParameter cenv (env:TcEnv) tpenv kind (v:SynType) idOpt cont
                 | Const.Bool b     -> record(cenv.g.bool_ty); box (b:bool)
                 | _ ->  fail()
             | _ -> error(Error(FSComp.SR.tcInvalidConstantExpression(),v.Range))
-        v, tpenv'   
+        PrettyNaming.StaticArg v, tpenv'   
     | SynType.LongIdent(lidwd) ->
         let m = lidwd.Range
         if typeEquiv cenv.g cenv.g.system_Type_typ kind then
@@ -4797,7 +4797,7 @@ and TcStaticConstantParameter cenv (env:TcEnv) tpenv kind (v:SynType) idOpt cont
             let st = assm.TxTType (snd (generalizeTyconRef tcref))
                 
             record(cenv.g.system_Type_typ); 
-            box st, tpenv
+            PrettyNaming.StaticArg (box st), tpenv
         else 
             TcStaticConstantParameter cenv env tpenv kind (SynType.StaticConstantExpr(SynExpr.LongIdent(false,lidwd,None,m),m)) idOpt container
     | _ ->  
@@ -4847,7 +4847,7 @@ and CrackStaticConstantArgs cenv env tpenv (staticParameters: Tainted<ProvidedPa
                     if sp.PUntaint((fun sp -> sp.IsOptional), m) then
                          match sp.PUntaint((fun sp -> sp.RawDefaultValue), m) with
                          | null -> error (Error(FSComp.SR.etStaticParameterRequiresAValue (spName, containerName, containerName, spName) ,m))
-                         | v -> v
+                         | v -> PrettyNaming.StaticArg v
                     else
                       error (Error(FSComp.SR.etStaticParameterRequiresAValue (spName, containerName, containerName, spName),m))
                  | ps -> 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -180,8 +180,7 @@ type DisposablesTracker() =
 let TypeCheck (ctok, tcConfig, tcImports, tcGlobals, errorLogger:ErrorLogger, assemblyName, niceNameGen, tcEnv0, inputs, exiter: Exiter) =
     try 
         if isNil inputs then error(Error(FSComp.SR.fscNoImplementationFiles(), Range.rangeStartup))
-        let ccuName = assemblyName
-        let tcInitialState = GetInitialTcState (rangeStartup, ccuName, tcConfig, tcGlobals, tcImports, niceNameGen, tcEnv0)
+        let tcInitialState = GetInitialTcState (rangeStartup, assemblyName, tcConfig, tcGlobals, tcImports, niceNameGen, tcEnv0)
         TypeCheckClosedInputSet (ctok, (fun () -> errorLogger.ErrorCount > 0), tcConfig, tcImports, tcGlobals, None, tcInitialState, inputs)
     with e -> 
         errorRecovery e rangeStartup
@@ -1269,7 +1268,7 @@ module StaticLinker =
                             match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
                             | Some dllInfo ->
                                 let ccu = 
-                                    match tcImports.FindCcuFromAssemblyRef (ctok, Range.rangeStartup, ilAssemRef) with 
+                                    match tcImports.FindCcuFromScopeRef (ctok, Range.rangeStartup, ILScopeRef.Assembly ilAssemRef) with 
                                     | ResolvedCcu ccu -> Some ccu
                                     | UnresolvedCcu(_ccuName) -> None
 
@@ -1338,7 +1337,7 @@ module StaticLinker =
               match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
               | Some dllInfo ->
                   let ccu = 
-                      match tcImports.FindCcuFromAssemblyRef (ctok, Range.rangeStartup, ilAssemRef) with 
+                      match tcImports.FindCcuFromScopeRef (ctok, Range.rangeStartup, ILScopeRef.Assembly ilAssemRef) with 
                       | ResolvedCcu ccu -> Some ccu
                       | UnresolvedCcu(_ccuName) -> None
 

--- a/src/fsharp/import.fsi
+++ b/src/fsharp/import.fsi
@@ -19,7 +19,7 @@ open Microsoft.FSharp.Compiler.ExtensionTyping
 type AssemblyLoader = 
 
     /// Resolve an Abstract IL assembly reference to a Ccu
-    abstract FindCcuFromAssemblyRef : CompilationThreadToken * range * ILAssemblyRef -> CcuResolutionResult
+    abstract FindCcuFromScopeRef : CompilationThreadToken * range * ILScopeRef -> CcuResolutionResult
 
 #if EXTENSIONTYPING
     /// Get a flag indicating if an assembly is a provided assembly, plus the

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -3601,8 +3601,12 @@ and
       /// A helper function used to link provided types
       ImportQualifiedTypeNameAsTypeValue : string * range -> System.Type
 
-      /// A helper function used to amortize the production of types as values
-      LinkTyconRefAsTypeValue : CcuThunk option * TyconRef * range -> System.Type
+      /// The data strcture to amortize the production of types as values
+      mutable ReflectAssembly : Lazy<System.Reflection.Assembly>
+
+      /// A hack used to get back to the assembly being compiled.  This is called when we 
+      // a type in the assembly being compiled has been used as a type argument to a type provider.
+      mutable GetCcuBeingCompiledHack : unit -> CcuThunk option
 
 #endif
       /// Indicates that this DLL uses pre-F#-4.0 quotation literals somewhere. This is used to implement a restriction on static linking
@@ -3693,7 +3697,8 @@ and CcuThunk =
 
       /// A helper function used to link provided types
     member ccu.ImportQualifiedTypeNameAsTypeValue (qname, m) : System.Type = ccu.Deref.ImportQualifiedTypeNameAsTypeValue (qname, m)
-    member ccu.LinkTyconRefAsTypeValue (thisCcuOpt, tcref, m) : System.Type = ccu.Deref.LinkTyconRefAsTypeValue (thisCcuOpt, tcref, m)
+    member ccu.ReflectAssembly = ccu.Deref.ReflectAssembly.Value
+    member ccu.GetCcuBeingCompiledHack() = ccu.Deref.GetCcuBeingCompiledHack()
       
 #endif
 


### PR DESCRIPTION
This now compiles:
```
#r "type_passing_tp/bin/Debug/type_passing_tp.dll"

open Test

type MyRecord = 
    { Id: string }
    member x.TestInstanceMember(y:string) = y
    static member TestStaticMember(y:string) = y

type Test = TypePassing.TypePassingTP<MyRecord>

type Test2 = TypePassing.TypePassingTP<System.Int32>

type Test3 = TypePassing.TypePassingTP<int32>
```
