### PR TITLE
Initial Generics support

### DIFF
--- a/src/fsharp/TastReflect.fs
+++ b/src/fsharp/TastReflect.fs
@@ -232,7 +232,10 @@ and ReflectTypeSymbol(kind: ReflectTypeSymbolKind, args: Type[]) =
         | ReflectTypeSymbolKind.Array _ -> typeof<System.Array>
         | ReflectTypeSymbolKind.Pointer -> typeof<System.ValueType>
         | ReflectTypeSymbolKind.ByRef -> typeof<System.ValueType>
-        | ReflectTypeSymbolKind.Generic gtd  -> instType (args, [| |]) gtd.BaseType
+        | ReflectTypeSymbolKind.Generic gtd  -> 
+            if gtd.BaseType = null
+            then null 
+            else instType (args, [| |]) gtd.BaseType
         
     override this.Assembly = 
         match kind, args with 
@@ -284,7 +287,15 @@ and ReflectTypeSymbol(kind: ReflectTypeSymbolKind, args: Type[]) =
     member this.Kind = kind
     member this.Args = args
     
-    override this.GetConstructors _bindingAttr                                                      = notRequired "GetConstructors" this.Name
+    override this.GetConstructors _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetConstructors(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetConstructors(_bindingAttr)
+        | _ -> failwith "unreachable"
+
     override this.GetMethodImpl(_ (* name *), _bindingAttr, _binderBinder, _callConvention, _ (* types *), _modifiers) = notRequired "ReflectTypeSymbol: GetMethodImpl" this.Name
         //match kind with
         //| ReflectTypeSymbolKind.Generic gtd -> 
@@ -333,19 +344,114 @@ and ReflectTypeSymbol(kind: ReflectTypeSymbolKind, args: Type[]) =
 
     override this.AssemblyQualifiedName                                                            = "[" + this.Assembly.FullName + "]" + this.FullName
 
-    override this.GetMembers _bindingAttr                                                           = notRequired "GetMembers" this.Name
-    override this.GetMethods _bindingAttr                                                           = notRequired "GetMethods" this.Name
-    override this.GetField(_name, _bindingAttr)                                                     = notRequired "GetField" this.Name
-    override this.GetFields _bindingAttr                                                            = notRequired "GetFields" this.Name
-    override this.GetInterface(_name, _ignoreCase)                                                  = notRequired "GetInterface" this.Name
-    override this.GetInterfaces()                                                                   = notRequired "GetInterfaces" this.Name
-    override this.GetEvent(_name, _bindingAttr)                                                     = notRequired "GetEvent" this.Name
-    override this.GetEvents _bindingAttr                                                            = notRequired "GetEvents" this.Name
-    override this.GetProperties _bindingAttr                                                        = notRequired "GetProperties" this.Name
+    override this.GetMembers _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetMembers(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetMembers(_bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetMethods _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetMethods(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetMethods(_bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetField(_name, _bindingAttr) =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetField(_name,_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetField(_name,_bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetFields _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetFields(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetFields(_bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetInterface(_name, _ignoreCase) =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetInterface(_name, _ignoreCase)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetInterface(_name, _ignoreCase)
+        | _ -> failwith "unreachable"
+
+    override this.GetInterfaces() =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetInterfaces()
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetInterfaces()
+        | _ -> failwith "unreachable"
+
+    override this.GetEvent(_name, _bindingAttr) =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetEvent(_name, _bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetEvent(_name, _bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetEvents _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetEvents(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetEvents(_bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetProperties _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetProperties(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetProperties(_bindingAttr)
+        | _ -> failwith "unreachable"
+
     override this.GetPropertyImpl(_name, _bindingAttr, _binder, _returnType, _types, _modifiers)    = notRequired "GetPropertyImpl" this.Name
-    override this.GetNestedTypes _bindingAttr                                                       = notRequired "GetNestedTypes" this.Name
-    override this.GetNestedType(_name, _bindingAttr)                                                = notRequired "GetNestedType" this.Name
-    override this.GetAttributeFlagsImpl()                                                           = notRequired "GetAttributeFlagsImpl" this.Name
+    override this.GetNestedTypes _bindingAttr =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetNestedTypes(_bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetNestedTypes(_bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetNestedType(_name, _bindingAttr) =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.GetNestedType(_name, _bindingAttr)
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.GetNestedType(_name, _bindingAttr)
+        | _ -> failwith "unreachable"
+
+    override this.GetAttributeFlagsImpl() =
+        match kind,args with 
+        | ReflectTypeSymbolKind.SDArray,[| arg |] 
+        | ReflectTypeSymbolKind.Array _,[| arg |] 
+        | ReflectTypeSymbolKind.Pointer,[| arg |]         
+        | ReflectTypeSymbolKind.ByRef,[| arg |] -> arg.Attributes
+        | ReflectTypeSymbolKind.Generic gtd, _ -> gtd.Attributes
+        | _ -> failwith "unreachable"
     
     override this.UnderlyingSystemType = (this :> Type)
 
@@ -920,6 +1026,12 @@ and ReflectTypeDefinition (asm: ReflectAssembly, declTyOpt: Type option, tcref: 
     member x.MakeMethodInfo (declTy,md) = TxMethodDef declTy md
     member x.MakeConstructorInfo (declTy,md) = TxConstructorDef declTy md
 
+    //interface IReflectableType with 
+    //    member x.GetTypeInfo() = 
+    //        { new TypeInfo() with 
+    //            member __.AsType() = x :?> Type 
+    //        }
+             
 
 and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
     inherit Assembly()
@@ -943,6 +1055,20 @@ and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
             match x.GetType(enc) with 
             | null -> null
             | t -> t.GetNestedType(nm2,BindingFlags.Public ||| BindingFlags.NonPublic)
+        elif nm.Contains("`") then
+            let argI, argE = nm.LastIndexOf("["), nm.LastIndexOf("]")
+            let i = nm.LastIndexOf(".", nm.LastIndexOf("`"))
+            let nsp,nm2, args = nm.[0..i-1], nm.[i+1..argI-1], nm.[argI+1..argE-1]
+            let genTypeArgs = 
+                args.Split([|","|], StringSplitOptions.RemoveEmptyEntries) 
+                |> Array.map (fun a ->
+                    match x.GetType(a) with
+                    | null -> Type.GetType(a)
+                    | a -> a
+                )
+            match x.TryBindType(Some nsp, nm2) with 
+            | Some t -> t.MakeGenericType(genTypeArgs)
+            | None -> null
         elif nm.Contains(".") then 
             let i = nm.LastIndexOf(".")
             let nsp,nm2 = nm.[0..i-1], nm.[i+1..]

--- a/src/fsharp/TastReflect.fs
+++ b/src/fsharp/TastReflect.fs
@@ -903,9 +903,9 @@ and ReflectTypeDefinition (asm: ReflectAssembly, declTyOpt: Type option, tcref: 
     override this.AssemblyQualifiedName                                                            = this.FullName + ", " + this.Assembly.FullName
 
     override this.ToString() = this.FullName
-
+    
     override __.GetGenericArguments() = gps
-    override __.GetGenericTypeDefinition() = notRequired "GetGenericTypeDefinition"
+    override __.GetGenericTypeDefinition() = this :> Type //notRequired "GetGenericTypeDefinition"
     override __.GetMember(_name, _memberType, _bindingFlags)                                                      = notRequired "TxILTypeDef: GetMember"
     override __.GUID                                                                                      = notRequired "TxILTypeDef: GUID"
     override __.GetCustomAttributes(_inherited)                                                            = notRequired "TxILTypeDef: GetCustomAttributes"
@@ -978,7 +978,7 @@ and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
         // TODO: may need something special for "System.Void"
         let typ = stripTyEqnsWrtErasure Erasure.EraseAll g typ
         match typ with 
-        | AppTy g (tcref, tinst) -> 
+        | AppTy g (tcref, _) -> 
             let ccuofTyconRef = 
                 match ccuOfTyconRef tcref with 
                 | Some ccuofTyconRef -> ccuofTyconRef
@@ -988,9 +988,10 @@ and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
                 | None -> failwith (sprintf "TODO: didn't get back to CCU being compiled for local tcref %s" tcref.DisplayName)
             let reflAssem = ccuofTyconRef.ReflectAssembly :?> ReflectAssembly
             let tcrefR = reflAssem.TxTypeDef None tcref
-            match tinst with 
-            | [] -> tcrefR 
-            | args -> tcrefR.MakeGenericType(Array.map asm.TxTType (Array.ofList args))  
+            tcrefR
+            //match tinst with 
+            //| [] -> tcrefR 
+            //| args -> tcrefR.MakeGenericType(Array.map asm.TxTType (Array.ofList args))  
         | ty when isArrayTy g ty -> 
             let ety = destArrayTy g ty 
             let etyR = asm.TxTType ety

--- a/src/fsharp/TastReflect.fs
+++ b/src/fsharp/TastReflect.fs
@@ -978,7 +978,7 @@ and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
         // TODO: may need something special for "System.Void"
         let typ = stripTyEqnsWrtErasure Erasure.EraseAll g typ
         match typ with 
-        | AppTy g (tcref, _) -> 
+        | AppTy g (tcref, tinst) -> 
             let ccuofTyconRef = 
                 match ccuOfTyconRef tcref with 
                 | Some ccuofTyconRef -> ccuofTyconRef
@@ -988,10 +988,9 @@ and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
                 | None -> failwith (sprintf "TODO: didn't get back to CCU being compiled for local tcref %s" tcref.DisplayName)
             let reflAssem = ccuofTyconRef.ReflectAssembly :?> ReflectAssembly
             let tcrefR = reflAssem.TxTypeDef None tcref
-            tcrefR
-            //match tinst with 
-            //| [] -> tcrefR 
-            //| args -> tcrefR.MakeGenericType(Array.map asm.TxTType (Array.ofList args))  
+            match tinst with 
+            | [] -> tcrefR 
+            | args -> tcrefR.MakeGenericType(Array.map asm.TxTType (Array.ofList args))  
         | ty when isArrayTy g ty -> 
             let ety = destArrayTy g ty 
             let etyR = asm.TxTType ety
@@ -1005,13 +1004,7 @@ and ReflectAssembly(g, ccu: CcuThunk, location:string) as asm =
             let etyR = destByrefTy g ty  |> asm.TxTType 
             etyR.MakeByRefType()  
         | ty when isTyparTy g ty -> 
-            // TODO: finish generic parameters
-            //let tp = destTyparTy g ty  
-            failwith "NYI: generic typars"
-    //        let (gps1:Type[]),(gps2:Type[]) = gps
-    //        if n < gps1.Length then gps1.[n] 
-    //        elif n < gps1.Length + gps2.Length then gps2.[n - gps1.Length] 
-    //        else failwith (sprintf "generic parameter index our of range: %d" n)
-    
+            let tp = destTyparTy g ty  
+            asm.TxTType (mkTyparTy tp)
         | _ -> failwithf "Unsupported TxTType %+A" typ
       

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4800,6 +4800,22 @@ and TcStaticConstantParameter cenv (env:TcEnv) tpenv kind (v:SynType) idOpt cont
             PrettyNaming.StaticArg (box st), tpenv
         else 
             TcStaticConstantParameter cenv env tpenv kind (SynType.StaticConstantExpr(SynExpr.LongIdent(false,lidwd,None,m),m)) idOpt container
+    | SynType.App (SynType.LongIdent(LongIdentWithDots(tc,_)),_,args,_commas,_,postfix,m) -> 
+        let ad = env.eAccessRights
+        let tcref = ForceRaise(ResolveTypeLongIdent cenv.tcSink cenv.nameResolver ItemOccurence.UseInType OpenQualified env.eNameResEnv ad tc (TypeNameResolutionStaticArgsInfo.FromTyArgs args.Length) PermitDirectReferenceToGeneratedType.No)
+        match tcref.TypeOrMeasureKind with
+        | TyparKind.Type ->
+            if postfix && tcref.Typars(m) |> List.exists (fun tp -> match tp.Kind with TyparKind.Measure -> true | _ -> false) 
+            then error(Error(FSComp.SR.tcInvalidUnitsOfMeasurePrefix(), m))
+           
+            let tyType, tpenv' = TcTypeApp cenv ImplictlyBoundTyparsAllowed.NewTyparsOK CheckConstraints.NoCheckCxs ItemOccurence.UseInType env tpenv m tcref [] args 
+            let assm = cenv.topCcu.ReflectAssembly :?> TastReflect.ReflectAssembly
+            let st = assm.TxTType tyType
+                
+            record(cenv.g.system_Type_typ); 
+            PrettyNaming.StaticArg (box st), tpenv'
+        | TyparKind.Measure ->
+            error(Error(FSComp.SR.tcInvalidConstantExpression(),v.Range))
     | _ ->  
         fail()
 

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/.gitignore
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/.gitignore
@@ -1,0 +1,4 @@
+packages/**
+paket-files/**
+.paket/**
+script.exe

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/iterate.bat
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/iterate.bat
@@ -1,0 +1,3 @@
+call msbuild 
+call ..\..\..\..\..\..\debug\net40\bin\fsc.exe script.fsx 
+call script.exe 

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/paket.lock
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/paket.lock
@@ -2,44 +2,44 @@ NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.57.4)
     FSharp.Core (4.1.2)
-      System.Collections (>= 4.0.11) - framework: >= netstandard16
-      System.Console (>= 4.0) - framework: >= netstandard16
-      System.Diagnostics.Debug (>= 4.0.11) - framework: >= netstandard16
-      System.Diagnostics.Tools (>= 4.0.1) - framework: >= netstandard16
-      System.Globalization (>= 4.0.11) - framework: >= netstandard16
-      System.IO (>= 4.1) - framework: >= netstandard16
-      System.Linq (>= 4.1) - framework: >= netstandard16
-      System.Linq.Expressions (>= 4.1) - framework: >= netstandard16
-      System.Linq.Queryable (>= 4.0.1) - framework: >= netstandard16
-      System.Net.Requests (>= 4.0.11) - framework: >= netstandard16
-      System.Reflection (>= 4.1) - framework: >= netstandard16
-      System.Reflection.Extensions (>= 4.0.1) - framework: >= netstandard16
-      System.Resources.ResourceManager (>= 4.0.1) - framework: >= netstandard16
-      System.Runtime (>= 4.1) - framework: >= netstandard16
-      System.Runtime.Extensions (>= 4.1) - framework: >= netstandard16
-      System.Runtime.Numerics (>= 4.0.1) - framework: >= netstandard16
-      System.Text.RegularExpressions (>= 4.1) - framework: >= netstandard16
-      System.Threading (>= 4.0.11) - framework: >= netstandard16
-      System.Threading.Tasks (>= 4.0.11) - framework: >= netstandard16
-      System.Threading.Tasks.Parallel (>= 4.0.1) - framework: >= netstandard16
-      System.Threading.Thread (>= 4.0) - framework: >= netstandard16
-      System.Threading.ThreadPool (>= 4.0.10) - framework: >= netstandard16
-      System.Threading.Timer (>= 4.0.1) - framework: >= netstandard16
-      System.ValueTuple (>= 4.3) - framework: >= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15
-    Microsoft.NETCore.Platforms (1.1) - framework: >= net10, >= netstandard10, netstandard13
-    Microsoft.NETCore.Targets (1.1) - framework: >= net10, >= netstandard10, netstandard13
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.native.System (4.3) - framework: >= netstandard16
+      System.Collections (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Console (>= 4.0) - restriction: >= netstandard1.6
+      System.Diagnostics.Debug (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Diagnostics.Tools (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Globalization (>= 4.0.11) - restriction: >= netstandard1.6
+      System.IO (>= 4.1) - restriction: >= netstandard1.6
+      System.Linq (>= 4.1) - restriction: >= netstandard1.6
+      System.Linq.Expressions (>= 4.1) - restriction: >= netstandard1.6
+      System.Linq.Queryable (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Net.Requests (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Reflection (>= 4.1) - restriction: >= netstandard1.6
+      System.Reflection.Extensions (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Resources.ResourceManager (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.1) - restriction: >= netstandard1.6
+      System.Runtime.Extensions (>= 4.1) - restriction: >= netstandard1.6
+      System.Runtime.Numerics (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Text.RegularExpressions (>= 4.1) - restriction: >= netstandard1.6
+      System.Threading (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Threading.Tasks (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Threading.Tasks.Parallel (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Threading.Thread (>= 4.0) - restriction: >= netstandard1.6
+      System.Threading.ThreadPool (>= 4.0.10) - restriction: >= netstandard1.6
+      System.Threading.Timer (>= 4.0.1) - restriction: >= netstandard1.6
+      System.ValueTuple (>= 4.3) - restriction: || (== netstandard1.0) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (== netstandard1.4) (== netstandard1.5) (>= net10)
+    Microsoft.NETCore.Platforms (1.1) - restriction: || (>= net10) (>= netstandard1.0)
+    Microsoft.NETCore.Targets (1.1) - restriction: || (>= net10) (>= netstandard1.0)
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.native.System (4.3) - restriction: >= netstandard1.6
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
-    runtime.native.System.Net.Http (4.3) - framework: >= netstandard16
+    runtime.native.System.Net.Http (4.3) - restriction: >= netstandard1.6
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
-    runtime.native.System.Security.Cryptography.Apple (4.3) - framework: >= netstandard16
+    runtime.native.System.Security.Cryptography.Apple (4.3) - restriction: >= netstandard1.6
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
       runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
@@ -50,380 +50,380 @@ NUGET
       runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3) - framework: >= netstandard16
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-    System.Collections (4.3) - framework: >= net10, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Collections.Concurrent (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Tracing (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Reflection (>= 4.3) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-    System.Console (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: >= netstandard13
-      System.IO (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Text.Encoding (>= 4.3) - framework: >= netstandard13
-    System.Diagnostics.Debug (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Diagnostics.DiagnosticSource (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: netstandard11, >= netstandard13
-      System.Diagnostics.Tracing (>= 4.3) - framework: netstandard11, >= netstandard13
-      System.Reflection (>= 4.3) - framework: netstandard11, >= netstandard13
-      System.Runtime (>= 4.3) - framework: netstandard11, >= netstandard13
-      System.Threading (>= 4.3) - framework: netstandard11, >= netstandard13
-    System.Diagnostics.Tools (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard10
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, >= netstandard10
-      System.Runtime (>= 4.3) - framework: dnxcore50, >= netstandard10
-    System.Diagnostics.Tracing (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-    System.Globalization (4.3) - framework: >= net10, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Globalization.Calendars (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: >= netstandard13
-      System.Globalization (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-    System.Globalization.Extensions (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      System.Globalization (>= 4.3) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: >= netstandard13
-      System.Runtime.InteropServices (>= 4.3) - framework: >= netstandard13
-    System.IO (4.3) - framework: >= net10, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Text.Encoding (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-    System.IO.FileSystem (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: >= netstandard13
-      System.IO (>= 4.3) - framework: >= netstandard13
-      System.IO.FileSystem.Primitives (>= 4.3) - framework: >= net46, >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Handles (>= 4.3) - framework: >= netstandard13
-      System.Text.Encoding (>= 4.3) - framework: >= netstandard13
-      System.Threading.Tasks (>= 4.3) - framework: >= netstandard13
-    System.IO.FileSystem.Primitives (4.3) - framework: >= netstandard16
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-    System.Linq (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard16
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-    System.Linq.Expressions (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.IO (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Linq (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.ObjectModel (>= 4.3) - framework: >= netstandard16
-      System.Reflection (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard16
-      System.Reflection.Emit (>= 4.3) - framework: >= netstandard16
-      System.Reflection.Emit.ILGeneration (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Reflection.Emit.Lightweight (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Reflection.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Reflection.Primitives (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Reflection.TypeExtensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard16
-    System.Linq.Queryable (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Linq (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Linq.Expressions (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Reflection (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Reflection.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Net.Http (4.3.1) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard13, >= netstandard16
-      runtime.native.System (>= 4.3) - framework: >= netstandard16
-      runtime.native.System.Net.Http (>= 4.3) - framework: >= netstandard16
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Diagnostics.DiagnosticSource (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Diagnostics.Tracing (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Globalization (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Globalization.Extensions (>= 4.3) - framework: >= netstandard16
-      System.IO (>= 4.3) - framework: dnxcore50, netstandard11, netstandard13, >= netstandard16
-      System.IO.FileSystem (>= 4.3) - framework: >= netstandard16
-      System.Net.Primitives (>= 4.3) - framework: dnxcore50, netstandard11, netstandard13, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard11, netstandard13, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Runtime.Handles (>= 4.3) - framework: netstandard13, >= netstandard16
-      System.Runtime.InteropServices (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.X509Certificates (>= 4.3) - framework: >= net46, dnxcore50, netstandard13, >= netstandard16
-      System.Text.Encoding (>= 4.3) - framework: dnxcore50, netstandard11, netstandard13, >= netstandard16
-      System.Threading (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard16
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard11, netstandard13, >= netstandard16
-    System.Net.Primitives (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, netstandard11, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, netstandard11, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard11, >= netstandard13
-      System.Runtime.Handles (>= 4.3) - framework: dnxcore50, >= netstandard13
-    System.Net.Requests (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Tracing (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.IO (>= 4.3) - framework: dnxcore50, netstandard10, netstandard11, >= netstandard13
-      System.Net.Http (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Net.Primitives (>= 4.3) - framework: dnxcore50, netstandard10, netstandard11, >= netstandard13
-      System.Net.WebHeaderCollection (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard11, >= netstandard13
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-    System.Net.WebHeaderCollection (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: >= netstandard13
-    System.ObjectModel (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard13
-    System.Reflection (4.3) - framework: >= net10, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.IO (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Reflection.Primitives (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-    System.Reflection.Emit (4.3) - framework: >= netstandard16
-      System.IO (>= 4.3) - framework: >= netstandard11
-      System.Reflection (>= 4.3) - framework: >= netstandard11
-      System.Reflection.Emit.ILGeneration (>= 4.3) - framework: >= netstandard11
-      System.Reflection.Primitives (>= 4.3) - framework: >= netstandard11
-      System.Runtime (>= 4.3) - framework: >= netstandard11
-    System.Reflection.Emit.ILGeneration (4.3) - framework: >= netstandard16
-      System.Reflection (>= 4.3) - framework: >= netstandard10
-      System.Reflection.Primitives (>= 4.3) - framework: >= netstandard10
-      System.Runtime (>= 4.3) - framework: >= netstandard10
-    System.Reflection.Emit.Lightweight (4.3) - framework: >= netstandard16
-      System.Reflection (>= 4.3) - framework: >= netstandard10
-      System.Reflection.Emit.ILGeneration (>= 4.3) - framework: >= netstandard10
-      System.Reflection.Primitives (>= 4.3) - framework: >= netstandard10
-      System.Runtime (>= 4.3) - framework: >= netstandard10
-    System.Reflection.Extensions (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard10
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, >= netstandard10
-      System.Reflection (>= 4.3) - framework: dnxcore50, >= netstandard10
-      System.Runtime (>= 4.3) - framework: dnxcore50, >= netstandard10
-    System.Reflection.Primitives (4.3) - framework: >= net10, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard10
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, >= netstandard10
-      System.Runtime (>= 4.3) - framework: dnxcore50, >= netstandard10
-    System.Reflection.TypeExtensions (4.3) - framework: >= netstandard16
-      System.Reflection (>= 4.3) - framework: >= net462, dnxcore50, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard15
-    System.Resources.ResourceManager (4.3) - framework: >= net10, >= netstandard10
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard10
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, >= netstandard10
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard10
-      System.Reflection (>= 4.3) - framework: dnxcore50, >= netstandard10
-      System.Runtime (>= 4.3) - framework: dnxcore50, >= netstandard10
-    System.Runtime (4.3) - framework: >= net10, >= netstandard10, netstandard13
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15
-    System.Runtime.Extensions (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-    System.Runtime.Handles (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-    System.Runtime.InteropServices (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      System.Reflection (>= 4.3) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      System.Reflection.Primitives (>= 4.3) - framework: dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: net462, >= net463, dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
-      System.Runtime.Handles (>= 4.3) - framework: dnxcore50, netstandard13, >= netstandard15
-    System.Runtime.Numerics (4.3) - framework: >= netstandard16
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard13
-    System.Security.Cryptography.Algorithms (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard16
-      runtime.native.System.Security.Cryptography.Apple (>= 4.3) - framework: >= netstandard16
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: >= netstandard16
-      System.IO (>= 4.3) - framework: >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.3) - framework: >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime.Handles (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime.InteropServices (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime.Numerics (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= net463, dnxcore50, >= netstandard16
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: net46, net461, >= net463, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Text.Encoding (>= 4.3) - framework: dnxcore50, >= netstandard16
-    System.Security.Cryptography.Cng (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: netstandard14, >= netstandard16
-      System.IO (>= 4.3) - framework: netstandard13, netstandard14, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: netstandard14, >= netstandard16
-      System.Runtime (>= 4.3) - framework: netstandard13, netstandard14, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: netstandard14, >= netstandard16
-      System.Runtime.Handles (>= 4.3) - framework: netstandard13, netstandard14, >= netstandard16
-      System.Runtime.InteropServices (>= 4.3) - framework: netstandard14, >= netstandard16
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: netstandard14, >= netstandard16
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16
-      System.Text.Encoding (>= 4.3) - framework: netstandard14, >= netstandard16
-    System.Security.Cryptography.Csp (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      System.IO (>= 4.3) - framework: >= netstandard13
-      System.Reflection (>= 4.3) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Handles (>= 4.3) - framework: >= netstandard13
-      System.Runtime.InteropServices (>= 4.3) - framework: >= netstandard13
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: >= net46, >= netstandard13
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= netstandard13
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: >= net46, >= netstandard13
-      System.Text.Encoding (>= 4.3) - framework: >= netstandard13
-      System.Threading (>= 4.3) - framework: >= netstandard13
-    System.Security.Cryptography.Encoding (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: >= netstandard13
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= netstandard13
-      System.Collections (>= 4.3) - framework: >= netstandard13
-      System.Collections.Concurrent (>= 4.3) - framework: >= netstandard13
-      System.Linq (>= 4.3) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Handles (>= 4.3) - framework: >= netstandard13
-      System.Runtime.InteropServices (>= 4.3) - framework: >= netstandard13
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: >= netstandard13
-      System.Text.Encoding (>= 4.3) - framework: >= netstandard13
-    System.Security.Cryptography.OpenSsl (4.3) - framework: >= netstandard16
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= net463, >= netstandard16, monoandroid, monotouch, xamarinios, xamarinmac
-      System.Collections (>= 4.3) - framework: >= netstandard16
-      System.IO (>= 4.3) - framework: >= net463, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard16
-      System.Runtime (>= 4.3) - framework: >= net463, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: >= net463, >= netstandard16
-      System.Runtime.Handles (>= 4.3) - framework: >= netstandard16
-      System.Runtime.InteropServices (>= 4.3) - framework: >= netstandard16
-      System.Runtime.Numerics (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: >= net463, >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= net463, >= netstandard16
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: >= net463, >= netstandard16
-      System.Text.Encoding (>= 4.3) - framework: >= netstandard16
-    System.Security.Cryptography.Primitives (4.3) - framework: >= netstandard16
-      System.Diagnostics.Debug (>= 4.3) - framework: >= netstandard13
-      System.Globalization (>= 4.3) - framework: >= netstandard13
-      System.IO (>= 4.3) - framework: >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard13
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Threading (>= 4.3) - framework: >= netstandard13
-      System.Threading.Tasks (>= 4.3) - framework: >= netstandard13
-    System.Security.Cryptography.X509Certificates (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard16
-      runtime.native.System (>= 4.3) - framework: >= netstandard16
-      runtime.native.System.Net.Http (>= 4.3) - framework: >= netstandard16
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Diagnostics.Debug (>= 4.3) - framework: >= netstandard16
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Globalization.Calendars (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.IO (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.IO.FileSystem (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.IO.FileSystem.Primitives (>= 4.3) - framework: >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime.Handles (>= 4.3) - framework: dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Runtime.InteropServices (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime.Numerics (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: net46, >= net461, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Security.Cryptography.Cng (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Security.Cryptography.Csp (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: net46, >= net461, dnxcore50, netstandard13, netstandard14, >= netstandard16
-      System.Security.Cryptography.OpenSsl (>= 4.3) - framework: >= netstandard16
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Text.Encoding (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard16
-    System.Text.Encoding (4.3) - framework: >= net10, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Text.RegularExpressions (4.3) - framework: >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard16
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard16
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard16
-    System.Threading (4.3) - framework: >= netstandard16
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Threading.Tasks (4.3) - framework: >= net10, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-    System.Threading.Tasks.Parallel (4.3) - framework: >= netstandard16
-      System.Collections.Concurrent (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Tracing (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard11, >= netstandard13
-    System.Threading.Thread (4.3) - framework: >= netstandard16
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-    System.Threading.ThreadPool (4.3) - framework: >= netstandard16
-      System.Runtime (>= 4.3) - framework: >= netstandard13
-      System.Runtime.Handles (>= 4.3) - framework: >= netstandard13
-    System.Threading.Timer (4.3) - framework: >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, >= netstandard12
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, >= netstandard12
-      System.Runtime (>= 4.3) - framework: dnxcore50, >= netstandard12
-    System.ValueTuple (4.3) - framework: >= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15
-      System.Collections (>= 4.3) - framework: >= netstandard10
-      System.Resources.ResourceManager (>= 4.3) - framework: >= netstandard10
-      System.Runtime (>= 4.3) - framework: >= netstandard10
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3) - restriction: >= netstandard1.6
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+    System.Collections (4.3) - restriction: || (>= net10) (>= netstandard1.0)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Collections.Concurrent (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Reflection (>= 4.3) - restriction: >= netstandard1.3
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+    System.Console (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
+      System.IO (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
+    System.Diagnostics.Debug (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Diagnostics.DiagnosticSource (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
+      System.Reflection (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
+      System.Threading (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
+    System.Diagnostics.Tools (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+    System.Diagnostics.Tracing (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+    System.Globalization (4.3) - restriction: || (>= net10) (>= netstandard1.0)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Globalization.Calendars (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
+      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+    System.Globalization.Extensions (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
+    System.IO (4.3) - restriction: || (== netstandard1.0) (== netstandard1.3) (>= net10) (>= netstandard1.5)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+    System.IO.FileSystem (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
+      System.IO (>= 4.3) - restriction: >= netstandard1.3
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
+      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
+      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
+    System.IO.FileSystem.Primitives (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+    System.Linq (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.6)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+    System.Linq.Expressions (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.IO (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Linq (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.ObjectModel (>= 4.3) - restriction: >= netstandard1.6
+      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.6)
+      System.Reflection.Emit (>= 4.3) - restriction: >= netstandard1.6
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Reflection.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Reflection.Primitives (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+    System.Linq.Queryable (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Linq (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Linq.Expressions (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Reflection.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Net.Http (4.3.1) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      runtime.native.System (>= 4.3) - restriction: >= netstandard1.6
+      runtime.native.System.Net.Http (>= 4.3) - restriction: >= netstandard1.6
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Diagnostics.DiagnosticSource (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Globalization.Extensions (>= 4.3) - restriction: >= netstandard1.6
+      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
+      System.IO.FileSystem (>= 4.3) - restriction: >= netstandard1.6
+      System.Net.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Runtime.Handles (>= 4.3) - restriction: || (== netstandard1.3) (>= netstandard1.6)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= net46) (>= netstandard1.6)
+      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
+      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
+    System.Net.Primitives (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
+      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+    System.Net.Requests (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
+      System.Net.Http (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Net.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
+      System.Net.WebHeaderCollection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+    System.Net.WebHeaderCollection (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: >= netstandard1.3
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
+    System.ObjectModel (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+    System.Reflection (4.3) - restriction: || (>= net10) (>= netstandard1.0)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.Reflection.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+    System.Reflection.Emit (4.3) - restriction: >= netstandard1.6
+      System.IO (>= 4.3) - restriction: >= netstandard1.1
+      System.Reflection (>= 4.3) - restriction: >= netstandard1.1
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: >= netstandard1.1
+      System.Reflection.Primitives (>= 4.3) - restriction: >= netstandard1.1
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.1
+    System.Reflection.Emit.ILGeneration (4.3) - restriction: >= netstandard1.6
+      System.Reflection (>= 4.3) - restriction: >= netstandard1.0
+      System.Reflection.Primitives (>= 4.3) - restriction: >= netstandard1.0
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.0
+    System.Reflection.Emit.Lightweight (4.3) - restriction: >= netstandard1.6
+      System.Reflection (>= 4.3) - restriction: >= netstandard1.0
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: >= netstandard1.0
+      System.Reflection.Primitives (>= 4.3) - restriction: >= netstandard1.0
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.0
+    System.Reflection.Extensions (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+    System.Reflection.Primitives (4.3) - restriction: || (== netstandard1.0) (== netstandard1.3) (>= net10) (>= netstandard1.5)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+    System.Reflection.TypeExtensions (4.3) - restriction: >= netstandard1.6
+      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.5)
+    System.Resources.ResourceManager (4.3) - restriction: || (>= net10) (>= netstandard1.0)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
+    System.Runtime (4.3) - restriction: || (>= net10) (>= netstandard1.0)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+    System.Runtime.Extensions (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
+    System.Runtime.Handles (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+    System.Runtime.InteropServices (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      System.Reflection.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
+      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.5)
+    System.Runtime.Numerics (4.3) - restriction: >= netstandard1.6
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+    System.Security.Cryptography.Algorithms (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      runtime.native.System.Security.Cryptography.Apple (>= 4.3) - restriction: >= netstandard1.6
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: >= netstandard1.6
+      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime.Numerics (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= net463) (>= netstandard1.6)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (== net46) (== net461) (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
+      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+    System.Security.Cryptography.Cng (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== netstandard1.4) (>= netstandard1.6)
+      System.IO (>= 4.3) - restriction: || (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
+      System.Runtime.Handles (>= 4.3) - restriction: || (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (== net46) (== net461) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (== net46) (== net461) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
+      System.Text.Encoding (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      System.IO (>= 4.3) - restriction: >= netstandard1.3
+      System.Reflection (>= 4.3) - restriction: >= netstandard1.3
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: >= netstandard1.3
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: >= netstandard1.3
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: >= netstandard1.3
+      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
+      System.Threading (>= 4.3) - restriction: >= netstandard1.3
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.3
+      System.Collections (>= 4.3) - restriction: >= netstandard1.3
+      System.Collections.Concurrent (>= 4.3) - restriction: >= netstandard1.3
+      System.Linq (>= 4.3) - restriction: >= netstandard1.3
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: >= netstandard1.3
+      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
+    System.Security.Cryptography.OpenSsl (4.3) - restriction: >= netstandard1.6
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: || (== monoandroid) (>= net463) (>= netstandard1.6)
+      System.Collections (>= 4.3) - restriction: >= netstandard1.6
+      System.IO (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.6
+      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.6
+      System.Runtime.Numerics (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.6
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netstandard1.6
+      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.3
+      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
+      System.IO (>= 4.3) - restriction: >= netstandard1.3
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Threading (>= 4.3) - restriction: >= netstandard1.3
+      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
+    System.Security.Cryptography.X509Certificates (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      runtime.native.System (>= 4.3) - restriction: >= netstandard1.6
+      runtime.native.System.Net.Http (>= 4.3) - restriction: >= netstandard1.6
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.6
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Globalization.Calendars (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.IO (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.IO.FileSystem (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.6
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime.Numerics (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (== net46) (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net461) (>= netstandard1.6)
+      System.Security.Cryptography.Cng (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Security.Cryptography.Csp (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== net46) (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net461) (>= netstandard1.6)
+      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+    System.Text.Encoding (4.3) - restriction: || (== netstandard1.0) (== netstandard1.3) (>= net10) (>= netstandard1.5)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Text.RegularExpressions (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
+    System.Threading (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Threading.Tasks (4.3) - restriction: || (== netstandard1.0) (== netstandard1.3) (>= net10) (>= netstandard1.5)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netstandard1.6
+      System.Collections.Concurrent (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
+      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
+    System.Threading.Thread (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+    System.Threading.ThreadPool (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
+      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
+    System.Threading.Timer (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.2)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.2)
+      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.2)
+    System.ValueTuple (4.3) - restriction: || (== netstandard1.0) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (== netstandard1.4) (== netstandard1.5) (>= net10)
+      System.Collections (>= 4.3) - restriction: >= netstandard1.0
+      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.0
+      System.Runtime (>= 4.3) - restriction: >= netstandard1.0
 
 GROUP SourceFiles
 

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/script.fsx
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/script.fsx
@@ -75,7 +75,7 @@ module MyGenericRecord =
     check "gcnkewcwpo21" S.Assembly_CustomAttributes_Count 0
 #endif
     check "gcnkewcwpo22" S.IsGenericType (T.IsGenericType)
-    inaccurate "gcnkewcwpo23" S.IsGenericTypeDefinition (T.IsGenericTypeDefinition) true //INACCURACY: this is wrong since we currently have no distinction between constructed and generalized type defs.
+    check "gcnkewcwpo23" S.IsGenericTypeDefinition (T.IsGenericTypeDefinition)
     check "gcnkewcwpo24" S.GetGenericArguments_Length (T.GetGenericArguments().Length)
    // TODO: rest of System.Type properties and methods
    // TODO: reset of FSharp Reflection methods 

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/script.fsx
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/script.fsx
@@ -92,9 +92,10 @@ module MyUnion =
     check "unkewcwpo13" S.IsTuple (FSharpType.IsTuple(T))
     inaccurate "unkewcwpo14" S.IsUnion (FSharpType.IsUnion(T)) false // INACCURACY:  Getting FSharp.Core reflection to give the right answer here is a  tricky as it looks for attributes that aren't in the TAST
     inaccurate "unkewcwpo15" S.GetPublicProperties_Length (T.GetProperties().Length) 2 // INACCURACY: this should also report the properties for the F# record fields (which are not in the TAST unfortunately)
-    check "unkewcwpo16" S.GetPublicConstructors_Length (T.GetConstructors().Length)  0  
+ 
     inaccurate "unkewcwpo17" S.GetPublicMethods_Length (T.GetMethods().Length)  4 // INACCURACY: like GetProperties, this should report the getter methods for the properties for the F# record fields (which are not in the TAST unfortunately)
 #if CURRENTLY_GIVES_COMPILATION_ERROR_NEED_TO_CHECK_IF_EXPECTED
+    check "unkewcwpo16" S.GetPublicConstructors_Length (T.GetConstructors().Length)  0 //MOVED: As give compile error with build net40 debug.. 
     check "unkewcwpo18" S.Assembly_EntryPoint_isNull true
     check "unkewcwpo19" S.GUID ""
     check "unkewcwpo20" (try S.Assembly_CodeBase; false with _ -> true) true

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/type_passing_tp.fs
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/type_passing_tp.fs
@@ -32,7 +32,9 @@ type TypePassingTp(config: TypeProviderConfig) as this =
         rootType.AddMember(ProvidedProperty("IsNestedPublic", typeof<bool>, GetterCode = (fun args -> let v = ty.IsNestedPublic in <@@ v  @@> ), IsStatic=true))        
         rootType.AddMember(ProvidedProperty("IsPublic", typeof<bool>, GetterCode = (fun args -> let v = ty.IsPublic in <@@ v  @@> ), IsStatic=true))        
         rootType.AddMember(ProvidedProperty("IsNotPublic", typeof<bool>, GetterCode = (fun args -> let v = ty.IsNotPublic in <@@ v  @@> ), IsStatic=true))        
-        rootType.AddMember(ProvidedProperty("IsSealed", typeof<bool>, GetterCode = (fun args -> let v = ty.IsSealed in <@@ v  @@> ), IsStatic=true))        
+        rootType.AddMember(ProvidedProperty("IsSealed", typeof<bool>, GetterCode = (fun args -> let v = ty.IsSealed in <@@ v  @@> ), IsStatic=true))     
+        rootType.AddMember(ProvidedProperty("IsGenericType", typeof<bool>, GetterCode = (fun args -> let v = ty.IsGenericType in <@@ v  @@> ), IsStatic=true))  
+        rootType.AddMember(ProvidedProperty("IsGenericTypeDefinition", typeof<bool>, GetterCode = (fun args -> let v = ty.IsGenericTypeDefinition in <@@ v  @@> ), IsStatic=true))         
         rootType.AddMember(ProvidedProperty("IsRecord", typeof<bool>, GetterCode = (fun args -> let v = Reflection.FSharpType.IsRecord(ty) in <@@ v  @@> ), IsStatic=true))        
         rootType.AddMember(ProvidedProperty("IsFunction", typeof<bool>, GetterCode = (fun args -> let v = Reflection.FSharpType.IsFunction(ty) in <@@ v  @@> ), IsStatic=true))        
         rootType.AddMember(ProvidedProperty("IsModule", typeof<bool>, GetterCode = (fun args -> let v = Reflection.FSharpType.IsModule(ty) in <@@ v  @@> ), IsStatic=true))        
@@ -41,7 +43,8 @@ type TypePassingTp(config: TypeProviderConfig) as this =
         rootType.AddMember(ProvidedProperty("IsUnion", typeof<bool>, GetterCode = (fun args -> let v = Reflection.FSharpType.IsUnion(ty) in <@@ v  @@> ), IsStatic=true))        
         rootType.AddMember(ProvidedProperty("GetPublicProperties_Length", typeof<int>, GetterCode = (fun args -> let v = ty.GetProperties().Length in <@@ v  @@> ), IsStatic=true))        
         rootType.AddMember(ProvidedProperty("GetPublicConstructors_Length", typeof<int>, GetterCode = (fun args -> let v = ty.GetConstructors().Length in <@@ v  @@> ), IsStatic=true))        
-        rootType.AddMember(ProvidedProperty("GetPublicMethods_Length", typeof<int>, GetterCode = (fun args -> let v = ty.GetMethods().Length in <@@ v  @@> ), IsStatic=true))        
+        rootType.AddMember(ProvidedProperty("GetPublicMethods_Length", typeof<int>, GetterCode = (fun args -> let v = ty.GetMethods().Length in <@@ v  @@> ), IsStatic=true))    
+        rootType.AddMember(ProvidedProperty("GetGenericArguments_Length", typeof<int>, GetterCode = (fun args -> let v = ty.GetGenericArguments().Length in <@@ v  @@> ), IsStatic=true))         
 
         // Raises error is used in program
         rootType.AddMember(ProvidedProperty("Assembly_CodeBase", typeof<string>, GetterCode = (fun args -> let v = ty.Assembly.CodeBase in <@@ v  @@> ), IsStatic=true))        

--- a/tests/fsharp/typeProviders/samples/TypePassing/Erasing/type_passing_tp.fsproj
+++ b/tests/fsharp/typeProviders/samples/TypePassing/Erasing/type_passing_tp.fsproj
@@ -52,4 +52,955 @@
     <Compile Include="type_passing_tp.fs" />
     <None Include="Script.fsx" />
   </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\net20\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.0.3')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\netstandard1.6\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v2.2' Or $(TargetFrameworkVersion) == 'v2.3' Or $(TargetFrameworkVersion) == 'v4.0.3' Or $(TargetFrameworkVersion) == 'v4.1' Or $(TargetFrameworkVersion) == 'v4.2' Or $(TargetFrameworkVersion) == 'v4.3' Or $(TargetFrameworkVersion) == 'v4.4' Or $(TargetFrameworkVersion) == 'v4.4W' Or $(TargetFrameworkVersion) == 'v5.0' Or $(TargetFrameworkVersion) == 'v5.1' Or $(TargetFrameworkVersion) == 'v6.0')) Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\portable-net45+netcore45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\portable-net45+netcore45+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile47')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>packages\FSharp.Core\lib\portable-net45+sl5+netcore45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.Collections">
+          <HintPath>packages\System.Collections\ref\netstandard1.0\System.Collections.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Collections">
+          <HintPath>packages\System.Collections\ref\netstandard1.3\System.Collections.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Collections.Concurrent">
+          <HintPath>packages\System.Collections.Concurrent\lib\netstandard1.3\System.Collections.Concurrent.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Collections.Concurrent">
+          <HintPath>packages\System.Collections.Concurrent\ref\netstandard1.3\System.Collections.Concurrent.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Console">
+          <HintPath>packages\System.Console\ref\netstandard1.3\System.Console.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Debug">
+          <HintPath>packages\System.Diagnostics.Debug\ref\netstandard1.3\System.Diagnostics.Debug.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.DiagnosticSource">
+          <HintPath>packages\System.Diagnostics.DiagnosticSource\lib\netstandard1.3\System.Diagnostics.DiagnosticSource.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Tools">
+          <HintPath>packages\System.Diagnostics.Tools\ref\netstandard1.0\System.Diagnostics.Tools.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Tracing">
+          <HintPath>packages\System.Diagnostics.Tracing\ref\netstandard1.5\System.Diagnostics.Tracing.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.Globalization">
+          <HintPath>packages\System.Globalization\ref\netstandard1.0\System.Globalization.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Globalization">
+          <HintPath>packages\System.Globalization\ref\netstandard1.3\System.Globalization.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Globalization.Calendars">
+          <HintPath>packages\System.Globalization.Calendars\ref\netstandard1.3\System.Globalization.Calendars.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Globalization.Extensions">
+          <HintPath>packages\System.Globalization.Extensions\ref\netstandard1.3\System.Globalization.Extensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>packages\System.IO\lib\net462\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>packages\System.IO\ref\netstandard1.0\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.3'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>packages\System.IO\ref\netstandard1.3\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>packages\System.IO\ref\netstandard1.5\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem">
+          <HintPath>packages\System.IO.FileSystem\ref\netstandard1.3\System.IO.FileSystem.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem.Primitives">
+          <HintPath>packages\System.IO.FileSystem.Primitives\lib\netstandard1.3\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem.Primitives">
+          <HintPath>packages\System.IO.FileSystem.Primitives\ref\netstandard1.3\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>packages\System.Linq\lib\netstandard1.6\System.Linq.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>packages\System.Linq\ref\netstandard1.6\System.Linq.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>packages\System.Linq.Expressions\lib\netstandard1.6\System.Linq.Expressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>packages\System.Linq.Expressions\ref\netstandard1.6\System.Linq.Expressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Linq.Queryable">
+          <HintPath>packages\System.Linq.Queryable\ref\netstandard1.0\System.Linq.Queryable.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Linq.Queryable">
+          <HintPath>packages\System.Linq.Queryable\lib\netstandard1.3\System.Linq.Queryable.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <HintPath>packages\System.Net.Http\ref\netstandard1.3\System.Net.Http.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.Primitives">
+          <HintPath>packages\System.Net.Primitives\ref\netstandard1.3\System.Net.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.Requests">
+          <HintPath>packages\System.Net.Requests\ref\netstandard1.3\System.Net.Requests.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Net.WebHeaderCollection">
+          <HintPath>packages\System.Net.WebHeaderCollection\lib\netstandard1.3\System.Net.WebHeaderCollection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Net.WebHeaderCollection">
+          <HintPath>packages\System.Net.WebHeaderCollection\ref\netstandard1.3\System.Net.WebHeaderCollection.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.ObjectModel">
+          <HintPath>packages\System.ObjectModel\lib\netstandard1.3\System.ObjectModel.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.ObjectModel">
+          <HintPath>packages\System.ObjectModel\ref\netstandard1.3\System.ObjectModel.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>packages\System.Reflection\ref\netstandard1.0\System.Reflection.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>packages\System.Reflection\ref\netstandard1.3\System.Reflection.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>packages\System.Reflection\ref\netstandard1.5\System.Reflection.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit">
+          <HintPath>packages\System.Reflection.Emit\ref\netstandard1.1\System.Reflection.Emit.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit">
+          <HintPath>packages\System.Reflection.Emit\lib\netstandard1.3\System.Reflection.Emit.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.ILGeneration">
+          <HintPath>packages\System.Reflection.Emit.ILGeneration\ref\netstandard1.0\System.Reflection.Emit.ILGeneration.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.ILGeneration">
+          <HintPath>packages\System.Reflection.Emit.ILGeneration\lib\netstandard1.3\System.Reflection.Emit.ILGeneration.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.Lightweight">
+          <HintPath>packages\System.Reflection.Emit.Lightweight\ref\netstandard1.0\System.Reflection.Emit.Lightweight.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Emit.Lightweight">
+          <HintPath>packages\System.Reflection.Emit.Lightweight\lib\netstandard1.3\System.Reflection.Emit.Lightweight.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Extensions">
+          <HintPath>packages\System.Reflection.Extensions\ref\netstandard1.0\System.Reflection.Extensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.Primitives">
+          <HintPath>packages\System.Reflection.Primitives\ref\netstandard1.0\System.Reflection.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>packages\System.Reflection.TypeExtensions\lib\netstandard1.5\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Reflection.TypeExtensions">
+          <HintPath>packages\System.Reflection.TypeExtensions\ref\netstandard1.5\System.Reflection.TypeExtensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Resources.ResourceManager">
+          <HintPath>packages\System.Resources.ResourceManager\ref\netstandard1.0\System.Resources.ResourceManager.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Runtime">
+          <HintPath>packages\System.Runtime\lib\net462\System.Runtime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime">
+          <HintPath>packages\System.Runtime\ref\netstandard1.0\System.Runtime.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.2'">
+      <ItemGroup>
+        <Reference Include="System.Runtime">
+          <HintPath>packages\System.Runtime\ref\netstandard1.2\System.Runtime.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4')">
+      <ItemGroup>
+        <Reference Include="System.Runtime">
+          <HintPath>packages\System.Runtime\ref\netstandard1.3\System.Runtime.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime">
+          <HintPath>packages\System.Runtime\ref\netstandard1.5\System.Runtime.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Extensions">
+          <HintPath>packages\System.Runtime.Extensions\ref\netstandard1.5\System.Runtime.Extensions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Handles">
+          <HintPath>packages\System.Runtime.Handles\ref\netstandard1.3\System.Runtime.Handles.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>packages\System.Runtime.InteropServices\ref\netcoreapp1.1\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>packages\System.Runtime.InteropServices\ref\netstandard1.5\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Numerics">
+          <HintPath>packages\System.Runtime.Numerics\ref\netstandard1.1\System.Runtime.Numerics.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Numerics">
+          <HintPath>packages\System.Runtime.Numerics\lib\netstandard1.3\System.Runtime.Numerics.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>packages\System.Security.Cryptography.Algorithms\ref\netstandard1.6\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Cng">
+          <HintPath>packages\System.Security.Cryptography.Cng\ref\netstandard1.6\System.Security.Cryptography.Cng.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Csp">
+          <HintPath>packages\System.Security.Cryptography.Csp\ref\netstandard1.3\System.Security.Cryptography.Csp.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Encoding">
+          <HintPath>packages\System.Security.Cryptography.Encoding\ref\netstandard1.3\System.Security.Cryptography.Encoding.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.OpenSsl">
+          <HintPath>packages\System.Security.Cryptography.OpenSsl\lib\netstandard1.6\System.Security.Cryptography.OpenSsl.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.OpenSsl">
+          <HintPath>packages\System.Security.Cryptography.OpenSsl\ref\netstandard1.6\System.Security.Cryptography.OpenSsl.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Primitives">
+          <HintPath>packages\System.Security.Cryptography.Primitives\lib\netstandard1.3\System.Security.Cryptography.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Primitives">
+          <HintPath>packages\System.Security.Cryptography.Primitives\ref\netstandard1.3\System.Security.Cryptography.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.X509Certificates">
+          <HintPath>packages\System.Security.Cryptography.X509Certificates\ref\netstandard1.4\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0'">
+      <ItemGroup>
+        <Reference Include="System.Text.Encoding">
+          <HintPath>packages\System.Text.Encoding\ref\netstandard1.0\System.Text.Encoding.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Text.Encoding">
+          <HintPath>packages\System.Text.Encoding\ref\netstandard1.3\System.Text.Encoding.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>packages\System.Text.RegularExpressions\ref\netcoreapp1.1\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>packages\System.Text.RegularExpressions\lib\netstandard1.6\System.Text.RegularExpressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>packages\System.Text.RegularExpressions\ref\netstandard1.6\System.Text.RegularExpressions.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Threading">
+          <HintPath>packages\System.Threading\lib\netstandard1.3\System.Threading.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading">
+          <HintPath>packages\System.Threading\ref\netstandard1.3\System.Threading.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0'">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks">
+          <HintPath>packages\System.Threading.Tasks\ref\netstandard1.0\System.Threading.Tasks.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks">
+          <HintPath>packages\System.Threading.Tasks\ref\netstandard1.3\System.Threading.Tasks.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks.Parallel">
+          <HintPath>packages\System.Threading.Tasks.Parallel\ref\netstandard1.1\System.Threading.Tasks.Parallel.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks.Parallel">
+          <HintPath>packages\System.Threading.Tasks.Parallel\lib\netstandard1.3\System.Threading.Tasks.Parallel.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>packages\System.Threading.Thread\lib\netstandard1.3\System.Threading.Thread.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>packages\System.Threading.Thread\ref\netstandard1.3\System.Threading.Thread.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')) Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac')">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>packages\System.Threading.ThreadPool\lib\netstandard1.3\System.Threading.ThreadPool.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>packages\System.Threading.ThreadPool\ref\netstandard1.3\System.Threading.ThreadPool.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0'))">
+      <ItemGroup>
+        <Reference Include="System.Threading.Timer">
+          <HintPath>packages\System.Threading.Timer\ref\netstandard1.2\System.Threading.Timer.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7')) Or ($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5'))">
+      <ItemGroup>
+        <Reference Include="System.ValueTuple">
+          <HintPath>packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.0.3')">
+      <ItemGroup>
+        <Reference Include="System.ValueTuple">
+          <HintPath>packages\System.ValueTuple\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>


### PR DESCRIPTION
Rough implementation of generics. Sadly this adds another inaccuracy to the test suit in the form of `IsGenericTypeDefinition` I think this is a flaw in the way I have decided to implement this as I don't consider the type args in `tastreflect.TxTType` instead I rely on `TcTypeApp` to construct the TType instance and then rely in the `ReflectedTypeDefinition` to provide the args, trouble is this doesn't then allow me to build the unconstructed type (or have I missed something simple?). //cc @dsyme  